### PR TITLE
feat: enable nat instance function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,13 @@
+data "terraform_remote_state" "dynamic" {
+  backend = "s3"
+
+  config = {
+    bucket = "terraform-state-weasel"
+    key    = "dynamic/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
 # network 생성
 module "network" {
   source                  = "./modules/network"
@@ -12,6 +22,8 @@ module "network" {
   map_public_ip_on_launch = true
   enable_dns_support      = true
   enable_dns_hostnames    = true
+  enable_nat_instance     = true
+  nat_instance_network_interface_id = data.terraform_remote_state.dynamic.outputs.bastion_host_network_interface_id
 }
 
 

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -23,10 +23,15 @@ output "internet_gateway_id" {
   value       = aws_internet_gateway.this.id
 }
 
+locals {
+  nat_gateway_id = var.enable_nat_instance ? null : (length(aws_nat_gateway.this) > 0 ? aws_nat_gateway.this[0].id : null)
+}
+
 output "nat_gateway_id" {
   description = "The ID of the NAT Gateway"
-  value       = aws_nat_gateway.this.id
+  value       = local.nat_gateway_id
 }
+
 
 output "public_route_table_id" {
   description = "The ID of the public route table."

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -52,8 +52,6 @@ variable "map_public_ip_on_launch" {
   default     = false
 }
 
-
-
 variable "enable_dns_support" {
   description = "Set to true to enable DNS support for the VPC."
   type        = bool
@@ -65,3 +63,16 @@ variable "enable_dns_hostnames" {
   type        = bool
   default     = true
 }
+
+variable "enable_nat_instance" {
+  description = "Set to true to enable NAT instance in the VPC."
+  type = bool
+  default = false
+}
+
+variable "nat_instance_network_interface_id" {
+  description = "The ID of the network interface to associate with the NAT instance."
+  type = string
+  default = ""
+}
+


### PR DESCRIPTION
## 설명

- Bastion Hosts를 NAT Instance로 사용하도록 설정.
- enable_nat_instance 변수에 true를 할당하면 NAT gateway와 eip를 삭제하고 private subnet의 route table에 NAT인스턴스의 네트워크 인터페이스로 라우트 하도록 설정
- enable_nat_instance 변수에 false를 할당하면 NAT gateway와 eip를 생성하고 원상 private subnet의 인스턴스들이 NAT Gateway를 통해 외부에 접근할 수 있도록 설정
